### PR TITLE
Fix raise_on_expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## Unreleased
+## 0.6.4
 
-Released YYYY-MM-DD
+Released 2023-10-30
 
-* No changes yet.
+* Fix `raise_on_expired` to properly raise `CertificateExpiredError` when the token is expired on verify.
 
 ## 0.6.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Released 2023-10-30
 
-* [GH2](https://github.com/tiwilliam/rsmime/pull/2) - Fix `raise_on_expired` to properly raise `CertificateExpiredError` when the token is expired on verify.
+* [#2](https://github.com/tiwilliam/rsmime/pull/2) - Fix `raise_on_expired` to properly raise `CertificateExpiredError` when the token is expired on verify.
 
 ## 0.6.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Released 2023-10-30
 
-* Fix `raise_on_expired` to properly raise `CertificateExpiredError` when the token is expired on verify.
+* [GH2](https://github.com/tiwilliam/rsmime/pull/2) - Fix `raise_on_expired` to properly raise `CertificateExpiredError` when the token is expired on verify.
 
 ## 0.6.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "rsmime"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "openssl",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsmime"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rsmime"
-version = "0.6.3"
+version = "0.6.4"
 description = "Python package for signing and verifying S/MIME messages"
 classifiers = [
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Broken after refactoring from singletons, we now need to extract certs on verify using `signers`.