### PR TITLE
Allow initializing Rsmime with in-memory certificate data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /site
 /target
 /.shadowenv.d
+.venv/
 *.so
 __pycache__/

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -23,6 +23,18 @@ except (SignError, CertificateError) as e:
     print("Failed to sign:", e)
 ```
 
+If you already have the PEM data in memory you can also provide it directly:
+
+```python
+from pathlib import Path
+from rsmime import Rsmime
+
+certificate = Path("some.crt").read_text()
+private_key = Path("some.key").read_text()
+
+client = Rsmime(cert_data=certificate, key_data=private_key)
+```
+
 ### Output
 
 ```bash

--- a/python/rsmime/__init__.pyi
+++ b/python/rsmime/__init__.pyi
@@ -1,13 +1,23 @@
 class Rsmime:
-    def __init__(self, cert_file: str, key_file: str) -> None:
-        """Initialize client and load certificate from disk.
+    def __init__(
+        self,
+        cert_file: str | None = ...,
+        key_file: str | None = ...,
+        *,
+        cert_data: str | None = ...,
+        key_data: str | None = ...,
+    ) -> None:
+        """Initialize client and load certificate material.
 
         Parameters:
-            cert_file: Path to certificate on disk.
-            key_file: Path to private key on disk.
+            cert_file: Path to certificate on disk. Mutually exclusive with ``cert_data``.
+            key_file: Path to private key on disk. Mutually exclusive with ``key_data``.
+            cert_data: PEM-encoded certificate contents provided as a string.
+            key_data: PEM-encoded private key contents provided as a string.
 
         Raises:
-            exceptions.CertificateError: If there is an error reading the certificate or key.
+            exceptions.CertificateError: If there is an error loading, parsing, or when
+                both a file path and in-memory value are provided for the same artifact.
         """
         ...
     def sign(self, message: bytes, *, detached: bool = False) -> bytes:


### PR DESCRIPTION
## Summary
- allow the Rsmime constructor to accept PEM strings in addition to file paths and validate conflicting inputs
- document the new initialization option and update type stubs
- extend the test suite to cover in-memory materials, validation errors, and ignore local virtual environments

## Testing
- .venv/bin/pytest

------
https://chatgpt.com/codex/tasks/task_e_68f34a2dfacc8331868f63ae89e1bc42