### PR TITLE
Support bytes-like certificate material

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /site
 /target
 /.shadowenv.d
+.venv/
 *.so
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 Released XXXX-XX-XX
 
+## 0.7.0
+
+Released 2025-10-19
+
 * [#3](https://github.com/tiwilliam/rsmime/pull/3) - Replace black with ruff for formatting.
+* [#4](https://github.com/tiwilliam/rsmime/pull/4) - Introduce ``cert_data`` and ``key_data`` options for supplying certificate material without temporary files.
 
 ## 0.6.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Released XXXX-XX-XX
 Released 2025-10-19
 
 * [#3](https://github.com/tiwilliam/rsmime/pull/3) - Replace black with ruff for formatting.
-* [#4](https://github.com/tiwilliam/rsmime/pull/4) - Introduce ``cert_data`` and ``key_data`` options for supplying certificate material without temporary files.
+* [#7](https://github.com/tiwilliam/rsmime/pull/7) - Introduce ``cert_data`` and ``key_data`` options for supplying certificate material without temporary files.
 
 ## 0.6.4
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "rsmime"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "openssl",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsmime"
-version = "0.6.4"
+version = "0.7.0"
 edition = "2021"
 
 [lib]

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -23,6 +23,29 @@ except (SignError, CertificateError) as e:
     print("Failed to sign:", e)
 ```
 
+If you already have the PEM data in memory you can also provide it directly as text or
+bytes-like objects:
+
+```python
+from pathlib import Path
+from rsmime import Rsmime
+
+certificate = Path("some.crt").read_text()
+private_key = Path("some.key").read_text()
+
+client = Rsmime(cert_data=certificate, key_data=private_key)
+
+certificate_bytes = Path("some.crt").read_bytes()
+private_key_bytes = Path("some.key").read_bytes()
+
+client = Rsmime(cert_data=certificate_bytes, key_data=private_key_bytes)
+
+client = Rsmime(
+    cert_data=bytearray(Path("some.crt").read_bytes()),
+    key_data=bytearray(Path("some.key").read_bytes()),
+)
+```
+
 ### Output
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rsmime"
-version = "0.6.4"
+version = "0.7.0"
 description = "Python package for signing and verifying S/MIME messages"
 classifiers = [
     "License :: OSI Approved :: MIT License",

--- a/python/rsmime/__init__.pyi
+++ b/python/rsmime/__init__.pyi
@@ -1,13 +1,27 @@
+from os import PathLike
+
 class Rsmime:
-    def __init__(self, cert_file: str, key_file: str) -> None:
-        """Initialize client and load certificate from disk.
+    def __init__(
+        self,
+        cert_file: str | PathLike[str] | None = ...,
+        key_file: str | PathLike[str] | None = ...,
+        *,
+        cert_data: str | bytes | bytearray | memoryview | None = ...,
+        key_data: str | bytes | bytearray | memoryview | None = ...,
+    ) -> None:
+        """Initialize client and load certificate material.
 
         Parameters:
-            cert_file: Path to certificate on disk.
-            key_file: Path to private key on disk.
+            cert_file: Path to certificate on disk. Mutually exclusive with ``cert_data``.
+            key_file: Path to private key on disk. Mutually exclusive with ``key_data``.
+            cert_data: PEM-encoded certificate contents provided as a string or bytes-like
+                object.
+            key_data: PEM-encoded private key contents provided as a string or bytes-like
+                object.
 
         Raises:
-            exceptions.CertificateError: If there is an error reading the certificate or key.
+            exceptions.CertificateError: If there is an error loading, parsing, or when
+                both a file path and in-memory value are provided for the same artifact.
         """
         ...
     def sign(self, message: bytes, *, detached: bool = False) -> bytes:

--- a/tests/test_rsmime.py
+++ b/tests/test_rsmime.py
@@ -1,6 +1,48 @@
+from pathlib import Path
+
 import pytest
 from callee import strings
+
 from rsmime import Rsmime, exceptions
+
+
+ATTACHED_SIGNATURE_REGEX = strings.Regex(
+    b'MIME-Version: 1.0\n'
+    b'Content-Disposition: attachment; filename="smime.p7m"\n'
+    b'Content-Type: application/x-pkcs7-mime; smime-type=signed-data; name="smime.p7m"\n'
+    b'Content-Transfer-Encoding: base64\n'
+    b'\n'
+    b'MIIJwQYJKoZIhvcNAQcCoIIJsjCCCa4CAQExDzANBglghkgBZQMEAgEFADASBgkq\n'
+    b'[A-Za-z0-9/+=\n]+\n'
+    b'\n'
+)
+
+DETACHED_SIGNATURE_REGEX = strings.Regex(
+    b'MIME-Version: 1.0\n'
+    b'Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----[A-Z0-9]+"\n\n'
+    b'This is an S/MIME signed message\n\n'
+    b'------[A-Z0-9]+\n'
+    b'abc\n'
+    b'------[A-Z0-9]+\n'
+    b'Content-Type: application/x-pkcs7-signature; name="smime.p7s"\n'
+    b'Content-Transfer-Encoding: base64\n'
+    b'Content-Disposition: attachment; filename="smime.p7s"\n'
+    b'\n'
+    b'MIIJugYJKoZIhvcNAQcCoIIJqzCCCacCAQExDzANBglghkgBZQMEAgEFADALBgkq\n'
+    b'[A-Za-z0-9/+=\n]+\n'
+    b'\n'
+    b'------[A-Z0-9]+--\n'
+    b'\n'
+)
+
+
+def _load_text(path: str) -> str:
+    return Path(path).read_text()
+
+
+def _load_bytes(path: str) -> bytes:
+    return Path(path).read_bytes()
+
 
 working_client = Rsmime('tests/data/certificate.crt', 'tests/data/certificate.key')
 expired_client = Rsmime('tests/data/expired.crt', 'tests/data/certificate.key')
@@ -9,36 +51,51 @@ expired_client = Rsmime('tests/data/expired.crt', 'tests/data/certificate.key')
 class TestRsmime:
     def test_sign(self):
         signed_data = working_client.sign(b'abc')
-        assert signed_data == strings.Regex(
-            b'MIME-Version: 1.0\n'
-            b'Content-Disposition: attachment; filename="smime.p7m"\n'
-            b'Content-Type: application/x-pkcs7-mime; smime-type=signed-data; name="smime.p7m"\n'
-            b'Content-Transfer-Encoding: base64\n'
-            b'\n'
-            b'MIIJwQYJKoZIhvcNAQcCoIIJsjCCCa4CAQExDzANBglghkgBZQMEAgEFADASBgkq\n'
-            b'[A-Za-z0-9/+=\n]+\n'
-            b'\n'
-        )
+        assert signed_data == ATTACHED_SIGNATURE_REGEX
 
     def test_sign_detached(self):
         signed_data = working_client.sign(b'abc', detached=True)
-        assert signed_data == strings.Regex(
-            b'MIME-Version: 1.0\n'
-            b'Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha-256"; boundary="----[A-Z0-9]+"\n\n'
-            b'This is an S/MIME signed message\n\n'
-            b'------[A-Z0-9]+\n'
-            b'abc\n'
-            b'------[A-Z0-9]+\n'
-            b'Content-Type: application/x-pkcs7-signature; name="smime.p7s"\n'
-            b'Content-Transfer-Encoding: base64\n'
-            b'Content-Disposition: attachment; filename="smime.p7s"\n'
-            b'\n'
-            b'MIIJugYJKoZIhvcNAQcCoIIJqzCCCacCAQExDzANBglghkgBZQMEAgEFADALBgkq\n'
-            b'[A-Za-z0-9/+=\n]+\n'
-            b'\n'
-            b'------[A-Z0-9]+--\n'
-            b'\n'
+        assert signed_data == DETACHED_SIGNATURE_REGEX
+
+    def test_sign_with_in_memory_material(self):
+        client = Rsmime(
+            cert_data=_load_text('tests/data/certificate.crt'),
+            key_data=_load_text('tests/data/certificate.key'),
         )
+
+        signed_data = client.sign(b'abc')
+
+        assert signed_data == ATTACHED_SIGNATURE_REGEX
+
+    def test_sign_with_in_memory_bytes_material(self):
+        client = Rsmime(
+            cert_data=_load_text('tests/data/certificate.crt').encode(),
+            key_data=_load_text('tests/data/certificate.key').encode(),
+        )
+
+        signed_data = client.sign(b'abc')
+
+        assert signed_data == ATTACHED_SIGNATURE_REGEX
+
+    def test_sign_with_in_memory_bytearray_material(self):
+        client = Rsmime(
+            cert_data=bytearray(_load_bytes('tests/data/certificate.crt')),
+            key_data=bytearray(_load_bytes('tests/data/certificate.key')),
+        )
+
+        signed_data = client.sign(b'abc')
+
+        assert signed_data == ATTACHED_SIGNATURE_REGEX
+
+    def test_sign_with_path_objects(self):
+        client = Rsmime(
+            Path('tests/data/certificate.crt'),
+            Path('tests/data/certificate.key'),
+        )
+
+        signed_data = client.sign(b'abc')
+
+        assert signed_data == ATTACHED_SIGNATURE_REGEX
 
     def test_sign_missing_cert(self):
         with pytest.raises(
@@ -63,6 +120,52 @@ class TestRsmime:
     def test_sign_empty_data(self):
         with pytest.raises(exceptions.SignError, match='Cannot sign empty data'):
             working_client.sign(b'')
+
+    def test_conflicting_certificate_inputs(self):
+        with pytest.raises(
+            exceptions.CertificateError,
+            match='Provide either cert_file or cert_data',
+        ):
+            Rsmime(
+                'tests/data/certificate.crt',
+                'tests/data/certificate.key',
+                cert_data=_load_text('tests/data/certificate.crt'),
+            )
+
+    def test_conflicting_key_inputs(self):
+        with pytest.raises(
+            exceptions.CertificateError,
+            match='Provide either key_file or key_data',
+        ):
+            Rsmime(
+                'tests/data/certificate.crt',
+                'tests/data/certificate.key',
+                key_data=_load_text('tests/data/certificate.key'),
+            )
+
+    def test_missing_certificate_input(self):
+        with pytest.raises(
+            exceptions.CertificateError,
+            match='cert_file or cert_data',
+        ):
+            Rsmime(key_data=_load_text('tests/data/certificate.key'))
+
+    def test_missing_key_input(self):
+        with pytest.raises(
+            exceptions.CertificateError,
+            match='key_file or key_data',
+        ):
+            Rsmime(cert_data=_load_text('tests/data/certificate.crt'))
+
+    def test_in_memory_material_requires_text_or_bytes(self):
+        with pytest.raises(
+            exceptions.CertificateError,
+            match='cert_data must be a str or bytes-like object',
+        ):
+            Rsmime(
+                cert_data=object(),
+                key_data=_load_text('tests/data/certificate.key'),
+            )
 
     def test_verify(self):
         data = b'abc'


### PR DESCRIPTION
## Summary
- allow the certificate loader to accept bytes-like objects in addition to text for in-memory initialization
- document the bytes-like initialization paths in the Python stub and getting started guide
- extend the test suite to cover bytearray inputs alongside the existing string and bytes cases

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68f34a2dfacc8331868f63ae89e1bc42