### PR TITLE
Handle existing artifact upload conflict

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ github.job }}-${{ matrix.target }}-${{ github.run_attempt }}
           path: dist
 
   windows:
@@ -62,7 +62,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ github.job }}-${{ matrix.target }}-${{ github.run_attempt }}
           path: dist
 
   macos:
@@ -84,7 +84,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ github.job }}-${{ matrix.target }}-${{ github.run_attempt }}
           path: dist
 
   sdist:
@@ -99,7 +99,7 @@ jobs:
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-${{ github.job }}-${{ github.run_attempt }}
           path: dist
 
   release:
@@ -109,7 +109,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          pattern: wheels-*-${{ github.run_attempt }}
+          merge-multiple: true
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         env:


### PR DESCRIPTION
Make artifact names unique and adjust artifact download to resolve `409 Conflict` errors during artifact upload.

The `409 Conflict` error occurs when `actions/upload-artifact@v4` tries to create an artifact with a name that already exists for the same workflow run, which is common in re-runs or across matrix jobs. By adding job, matrix, and run attempt to the artifact names, each upload becomes unique. The subsequent download step is updated to collect all these uniquely named artifacts.

---
<a href="https://cursor.com/background-agent?bcId=bc-53d49aa9-23d5-41a7-b7c3-a0589e3eff57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-53d49aa9-23d5-41a7-b7c3-a0589e3eff57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

