### PR TITLE
Download filtered artifacts by pattern

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          pattern: wheels-*-${{ github.run_attempt }}
+          pattern: wheels-*
           merge-multiple: true
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1


### PR DESCRIPTION
Update artifact download pattern to `wheels-*` to correctly match artifact names and ensure artifacts are found across multiple run attempts.

The previous pattern `wheels-*-${{ github.run_attempt }}` would fail to find artifacts if the `github.run_attempt` changed (e.g., rerunning a job after a failure). Artifacts from an initial run attempt (e.g., `wheels-*-1`) would not be matched by a subsequent run attempt (e.g., `wheels-*-2`). Changing the pattern to `wheels-*` ensures all `wheels-*` artifacts are downloaded, making the workflow more robust to job reruns.

---
<a href="https://cursor.com/background-agent?bcId=bc-dbea63a8-e80c-4c4e-8104-4a6d5c49a1fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dbea63a8-e80c-4c4e-8104-4a6d5c49a1fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

