### PR TITLE
Fix mike deployment module error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "mkdocs-autorefs==0.5.0",
     "mkdocs-material==9.4.7",
     "mkdocstrings[python]==0.23.0",
+    "setuptools",
     "pytest==7.4.3",
     "ruff==0.1.3",
 ]


### PR DESCRIPTION
Add `setuptools` to dev dependencies to resolve `ModuleNotFoundError: No module named 'pkg_resources'` when running `mike deploy`.

---
<a href="https://cursor.com/background-agent?bcId=bc-f38ea0aa-54da-406e-b140-f017f992750e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f38ea0aa-54da-406e-b140-f017f992750e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

