### PR TITLE
Build documentation with mkdocstrings fix

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,8 @@ plugins:
         python:
           paths: [python]
           options:
+            allow_inspection: true
+            load_external_modules: true
             heading_level: 3
             show_source: false
             docstring_section_style: list

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,8 @@ plugins:
           options:
             allow_inspection: true
             load_external_modules: true
+            preload_modules:
+              - rsmime.rsmime
             heading_level: 3
             show_source: false
             docstring_section_style: list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ dev = [
     "mkdocs-autorefs==0.5.0",
     "mkdocs-material==9.4.7",
     "mkdocstrings[python]==0.23.0",
-    "setuptools",
+    "mkdocstrings-python==1.9.1",
+    "griffe<0.40",
+    "setuptools<81",
     "pytest==7.4.3",
     "ruff==0.1.3",
 ]

--- a/python/rsmime/__init__.py
+++ b/python/rsmime/__init__.py
@@ -1,8 +1,36 @@
+"""Public package interface for the compiled `rsmime` extension.
+
+This module imports all public symbols from the compiled extension module and
+adjusts metadata so that tools relying on introspection (e.g. mkdocstrings)
+can correctly resolve symbols to this package namespace.
+"""
+
 # ruff: noqa
 # type: ignore
 
-from .rsmime import *
+from . import rsmime as _ext
+from .rsmime import *  # re-export public API from the extension
 
-__doc__ = rsmime.__doc__
-if hasattr(rsmime, '__all__'):
-    __all__ = rsmime.__all__
+# Propagate module docstring and explicit export list if present on the extension
+__doc__ = getattr(_ext, "__doc__", __doc__)
+if hasattr(_ext, "__all__"):
+    __all__ = _ext.__all__
+
+# Help documentation tools resolve symbols to this package instead of builtins.
+try:  # best-effort: some attributes may be read-only depending on the build
+    if hasattr(_ext, "Rsmime"):
+        _ext.Rsmime.__module__ = __name__
+except Exception:
+    pass
+
+# Ensure the exceptions submodule is available as `rsmime.exceptions` even if
+# the extension exposes it under a top-level name.
+try:
+    import sys as _sys
+
+    if hasattr(_ext, "exceptions"):
+        _ext.exceptions.__name__ = f"{__name__}.exceptions"
+        _ext.exceptions.__package__ = __name__
+        _sys.modules.setdefault(f"{__name__}.exceptions", _ext.exceptions)
+except Exception:
+    pass

--- a/python/rsmime/rsmime.pyi
+++ b/python/rsmime/rsmime.pyi
@@ -1,0 +1,16 @@
+from os import PathLike
+
+class Rsmime:
+    def __init__(
+        self,
+        cert_file: str | PathLike[str] | None = ...,
+        key_file: str | PathLike[str] | None = ...,
+        *,
+        cert_data: str | bytes | bytearray | memoryview | None = ...,
+        key_data: str | bytes | bytearray | memoryview | None = ...,
+    ) -> None: ...
+
+    def sign(self, message: bytes, *, detached: bool = False) -> bytes: ...
+
+    @staticmethod
+    def verify(message: bytes, raise_on_expired: bool = False) -> bytes: ...


### PR DESCRIPTION
Pin documentation dependencies and adjust `rsmime` module introspection to fix the `griffe.collections` import error during docs build.

The `ModuleNotFoundError: No module named 'griffe.collections'` occurred because `mkdocstrings` and `griffe` versions were incompatible, and `mkdocstrings` was unable to properly introspect the compiled `rsmime` extension module. This PR pins compatible versions, enables `mkdocstrings` inspection, preloads the `rsmime` module, and explicitly sets `__module__` and `sys.modules` for the extension's classes and exceptions to aid introspection.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac73b3a8-5e34-4385-bfbb-52419973a1e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ac73b3a8-5e34-4385-bfbb-52419973a1e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

